### PR TITLE
PB14250: dual link-freq for OVTI05C1 + swnode self-heal — streaming confirmed on Ubuntu

### DIFF
--- a/dkms/ipu-bridge-patched-1.0/ipu-bridge.c
+++ b/dkms/ipu-bridge-patched-1.0/ipu-bridge.c
@@ -83,7 +83,7 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
 	/* Omnivision OV02E10 */
 	IPU_SENSOR_CONFIG("OVTI02E1", 1, 360000000),
 	/* Omnivision ov05c10 */
-	IPU_SENSOR_CONFIG("OVTI05C1", 1, 480000000),
+	IPU_SENSOR_CONFIG("OVTI05C1", 2, 480000000, 900000000),
 	/* Omnivision OV08A10 */
 	IPU_SENSOR_CONFIG("OVTI08A1", 1, 500000000),
 	/* Omnivision OV08x40 */

--- a/dkms/ov05c10-1.0/ov05c10.c
+++ b/dkms/ov05c10-1.0/ov05c10.c
@@ -7,6 +7,7 @@
 #include <linux/i2c.h>
 #include <linux/module.h>
 #include <linux/pm_runtime.h>
+#include <linux/property.h>
 #include <linux/units.h>
 #include <linux/regmap.h>
 #include <linux/version.h>
@@ -899,8 +900,43 @@ static int ov05c10_parse_fwnode(struct ov05c10 *ov05c10, struct device *dev)
 
 	endpoint = fwnode_graph_get_next_endpoint(fwnode, NULL);
 	if (!endpoint) {
-		dev_err(dev, "endpoint node not found\n");
-		return -EPROBE_DEFER;
+		/*
+		 * After an SVP7500/CVS chip reset the USB i2c adapter
+		 * re-enumerates and this i2c client is destroyed and
+		 * re-created. ACPI unbind of the dead client poisons the
+		 * ACPI fwnode's ->secondary (set_primary_fwnode(dev, NULL)
+		 * leaves ERR_PTR(-ENODEV)), orphaning the ipu-bridge swnode
+		 * graph that is still registered. Re-attach it and retry so
+		 * the camera survives a CVS reset without a reboot.
+		 */
+		const struct software_node *swn =
+			software_node_find_by_name(NULL, "OVTI05C1-0");
+
+		if (swn && is_acpi_device_node(fwnode)) {
+			fwnode->secondary = software_node_fwnode(swn);
+			endpoint = fwnode_graph_get_next_endpoint(fwnode, NULL);
+			dev_info(dev, "re-attached ipu-bridge swnode graph%s\n",
+				 endpoint ? "" : " (still no endpoint)");
+			/*
+			 * Bank an extra kobject ref on the swnode: the i2c
+			 * client teardown path over-puts non-managed
+			 * secondary swnodes (one ref lost per destroy/create
+			 * cycle), and once the refcount hits zero the node is
+			 * freed and recovery is impossible until reboot
+			 * (observed live: node vanished after two cycles).
+			 * One banked ref per heal keeps the balance positive.
+			 */
+			if (endpoint)
+				software_node_find_by_name(NULL, "OVTI05C1-0");
+		}
+		if (!endpoint) {
+			dev_err(dev, "endpoint node not found (swn=%d acpi=%d sec=%ld)\n",
+				!!swn, is_acpi_device_node(fwnode),
+				IS_ERR(fwnode->secondary) ?
+					PTR_ERR(fwnode->secondary) :
+					(long)!!fwnode->secondary);
+			return -EPROBE_DEFER;
+		}
 	}
 
 	ret = v4l2_fwnode_endpoint_alloc_parse(endpoint, &bus_cfg);


### PR DESCRIPTION
Two fixes from bringing up a **Dell Pro 14 Plus PB14250** (Lunar Lake, OV05C10) on **Ubuntu 26.04** / kernel 7.0.0-1008-oem — this upgrades the PB14250 row from "install confirmed, streaming TBD" to **streaming confirmed**, and confirms the pack works on Ubuntu.

### 1. ipu-bridge: advertise both link freqs for OVTI05C1

The ov05c10 driver requires both 480MHz and 900MHz in the fwnode link-frequencies or probe fails with -EINVAL ("no link frequency supported"). With the current 480MHz-only entry the sensor never binds on the PB14250. Note the 900M *path* still appears broken on this board (native 2880×1808 hangs; ≤1080p with an explicit `-s` streams fine at 17–31 fps) — but the driver refuses to probe unless both frequencies are advertised.

### 2. ov05c10: survive i2c client re-creation (swnode self-heal)

When the SVP7500 re-enumerates (suspend/resume quirks, chip reset, flaky boot), its USB i2c adapters are torn down and the sensor client is destroyed and re-created. The new client can't find its fwnode graph endpoint and probe defers forever — camera dead until reboot.

Root cause is an upstream kernel bug (will report separately): `i2c_unregister_device()` unconditionally calls `device_remove_software_node()`, which for the ipu-bridge swnode (attached to the ACPI companion as secondary, never added via `device_add_software_node`) both severs the secondary link and drops a kobject ref it never took. Net −1 ref per client lifecycle; after a couple of cycles the swnode is freed outright and the camera is unrecoverable.

The workaround: on endpoint-lookup failure, re-attach the still-registered sensor swnode by name and bank one extra reference per heal. Verified across 5+ re-enumeration cycles on the PB14250: probe recovers, isys rebinds the subdev, streaming works — no reboot. (Bonus this enables: turning the latched privacy LED off without reboot by power-cycling the bridge's USB port — happy to write that up if wanted.)

### Ubuntu notes (for the README's untested list)

Works, with one gotcha: Ubuntu 26.04 uses **dracut**, so `ipu7_fw.bin` must be added to the initramfs (`install_items+=" /lib/firmware/intel/ipu/ipu7_fw.bin "` in `/etc/dracut.conf.d/`) or the intel-ipu7 probe fails -ENOENT at t≈1s and the whole graph cascades. Might be worth a README note or an installer check.

No pressure to take this — feel free to close if it doesn't fit your plans; the fixes live on in my fork either way. Mainly wanted the PB14250/Ubuntu confirmation and the re-enumeration analysis on your radar.

---
*Code and report written by an AI assistant (Claude) working with me (@dalandro); all results are from live testing on my PB14250 and I can re-verify or test variations on request.*
